### PR TITLE
Ajc t41 delete a post

### DIFF
--- a/SQL/UpdateScriptPost.sql
+++ b/SQL/UpdateScriptPost.sql
@@ -1,0 +1,26 @@
+﻿ALTER TABLE PostTag
+   DROP CONSTRAINT FK_PostTag_Post;
+
+ALTER TABLE PostTag
+    ADD CONSTRAINT FK_PostTag_Post
+    FOREIGN KEY (PostId)
+    REFERENCES Post (Id)
+    ON DELETE CASCADE;
+
+ALTER TABLE Comment
+    DROP CONSTRAINT FK_Comment_Post;
+
+ALTER TABLE Comment
+    ADD CONSTRAINT FK_Comment_Post
+    FOREIGN KEY (PostId)
+    REFERENCES Post (Id)
+    ON DELETE CASCADE;
+
+ALTER TABLE PostReaction
+    DROP CONSTRAINT FK_PostReaction_Post;
+
+ALTER TABLE PostReaction
+    ADD CONSTRAINT FK_PostReaction_Post
+    FOREIGN KEY (PostId)
+    REFERENCES Post (Id)
+    ON DELETE CASCADE;

--- a/Tabloid/Controllers/PostController.cs
+++ b/Tabloid/Controllers/PostController.cs
@@ -62,5 +62,12 @@ namespace Tabloid.Controllers
             var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
             return _userProfileRepository.GetByFirebaseUserId(firebaseUserId);
         }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            _postRepository.Delete(id);
+            return NoContent();
+        }
     }
 }

--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -33,6 +33,21 @@ namespace Tabloid.Controllers
             return Ok();
         }
 
+        //[HttpGet("LoggedInUserCheck")]
+        //public IActionResult CurrentUserCheck(string firebaseUserId)
+        //{
+        //    var currentUserProfie = _userProfileRepository.GetByFirebaseUserId(firebaseUserId);
+        //    UserProfile userProfile = GetCurrentUserProfile();
+        //    if (currentUserProfie.Id == userProfile.Id)
+        //    {
+        //        return Ok();
+        //    }
+        //    else
+        //    {
+        //        throw new Exception("User not a match");
+        //    }
+        //}
+
         [HttpPost]
         public IActionResult Post(UserProfile userProfile)
         {
@@ -44,10 +59,10 @@ namespace Tabloid.Controllers
                 new { firebaseUserId = userProfile.FirebaseUserId },
                 userProfile);
         }
-        private int GetCurrentUserProfileId()
+        private UserProfile GetCurrentUserProfile()
         {
-            string id = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            return int.Parse(id);
+            var firebaseUserId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
+            return _userProfileRepository.GetByFirebaseUserId(firebaseUserId);
         }
     }
 }

--- a/Tabloid/Repositories/PostRepository.cs
+++ b/Tabloid/Repositories/PostRepository.cs
@@ -39,7 +39,19 @@ namespace Tabloid.Repositories
 
         public void Delete(int id)
         {
-            throw new System.NotImplementedException();
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE FROM Post
+                        WHERE Id = @Id";
+
+                    DbUtils.AddParameter(cmd, "@id", id);
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         public List<Post> GetAll()

--- a/Tabloid/Repositories/PostRepository.cs
+++ b/Tabloid/Repositories/PostRepository.cs
@@ -63,7 +63,7 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"SELECT p.Id, p.Title, p.Content, p.ImageLocation, p.CreateDateTime, p.PublishDateTime, p.IsApproved, p.CategoryId, p.UserProfileId,
 		                                       
-                                               up.DisplayName, up.FirstName, up.LastName,
+                                               up.DisplayName, up.FirstName, up.LastName, up.FirebaseUserId,
 
                                                c.Name AS CategoryName
 
@@ -90,6 +90,7 @@ namespace Tabloid.Repositories
                                 UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
                                 UserProfile = new UserProfile()
                                 {
+                                    FirebaseUserId = DbUtils.GetString(reader, "FirebaseUserId"),
                                     Id = DbUtils.GetInt(reader, "UserProfileId"),
                                     DisplayName = DbUtils.GetString(reader, "DisplayName"),
                                     FirstName = DbUtils.GetString(reader, "FirstName"),
@@ -116,7 +117,7 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"SELECT p.Id, p.Title, p.Content, p.ImageLocation, p.CreateDateTime, p.PublishDateTime, p.IsApproved, p.CategoryId, p.UserProfileId,
 		                                       
-                                               up.DisplayName, up.FirstName, up.LastName,
+                                               up.DisplayName, up.FirstName, up.LastName, up.FirebaseUserId,
 
                                                c.Name AS CategoryName
 
@@ -144,6 +145,7 @@ namespace Tabloid.Repositories
                                 UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
                                 UserProfile = new UserProfile()
                                 {
+                                    FirebaseUserId = DbUtils.GetString(reader, "FirebaseUserId"),
                                     Id = DbUtils.GetInt(reader, "UserProfileId"),
                                     DisplayName = DbUtils.GetString(reader, "DisplayName"),
                                     FirstName = DbUtils.GetString(reader, "FirstName"),
@@ -172,7 +174,7 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"SELECT p.Id, p.Title, p.Content, p.ImageLocation, p.CreateDateTime, p.PublishDateTime, p.IsApproved, p.CategoryId, p.UserProfileId,
 		                                       
-                                               up.DisplayName, up.FirstName, up.LastName,
+                                               up.DisplayName, up.FirstName, up.LastName, up.FirebaseUserId,
 
                                                c.Name AS CategoryName
 
@@ -200,6 +202,7 @@ namespace Tabloid.Repositories
                                 UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
                                 UserProfile = new UserProfile()
                                 {
+                                    FirebaseUserId = DbUtils.GetString(reader, "FirebaseUserId"),
                                     Id = DbUtils.GetInt(reader, "UserProfileId"),
                                     DisplayName = DbUtils.GetString(reader, "DisplayName"),
                                     FirstName = DbUtils.GetString(reader, "FirstName"),

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -12,6 +12,7 @@ import { PostForm } from "./Posts/PostForm";
 import { TagForm } from "./tag/TagForm";
 import CatAddForm from "./category/AddCategoryForm";
 import { TagDelete } from "./tag/TagDelete";
+import { PostDelete } from "./Posts/PostDelete";
 
 export default function ApplicationViews({ isLoggedIn }) {
   return (
@@ -36,6 +37,7 @@ export default function ApplicationViews({ isLoggedIn }) {
           <Route path="posts">
             <Route index element={<PostList/>} />
             <Route path=":id" element={<PostDetails />} />
+            <Route path="delete/:id" element={<PostDelete />}/>
             <Route path="user" element={isLoggedIn ? <UserPostList /> : <Navigate to="/login" />} />
             <Route path="create" element={isLoggedIn ? <PostForm /> : <Navigate to="/login" />} />
           </Route>

--- a/Tabloid/client/src/components/Posts/Post.js
+++ b/Tabloid/client/src/components/Posts/Post.js
@@ -1,8 +1,12 @@
 import React from "react";
-import { Card, CardBody } from "reactstrap";
+import { Button, Card, CardBody } from "reactstrap";
+import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
 
 export const Post = ({ post }) => {
+
+    const navigate = useNavigate();
+    
     return(
         <Card>
             <CardBody>
@@ -11,7 +15,12 @@ export const Post = ({ post }) => {
                 </Link>
                 <h6>By: {post.userProfile.displayName}</h6>
                 <p>Category: {post.category.name}</p>
+                <Button color="danger" onClick={() => navigate(`/posts/delete/${post.id}`)}>
+                    Delete
+                </Button>
             </CardBody>
         </Card>
     )
 }
+
+export default Post;

--- a/Tabloid/client/src/components/Posts/Post.js
+++ b/Tabloid/client/src/components/Posts/Post.js
@@ -2,10 +2,13 @@ import React from "react";
 import { Button, Card, CardBody } from "reactstrap";
 import { useNavigate } from "react-router-dom";
 import { Link } from "react-router-dom";
+import firebase from "firebase/app";
+import "firebase/auth";
 
 export const Post = ({ post }) => {
 
     const navigate = useNavigate();
+    const uId = firebase.auth().currentUser.uid;
     
     return(
         <Card>
@@ -15,9 +18,11 @@ export const Post = ({ post }) => {
                 </Link>
                 <h6>By: {post.userProfile.displayName}</h6>
                 <p>Category: {post.category.name}</p>
-                <Button color="danger" onClick={() => navigate(`/posts/delete/${post.id}`)}>
-                    Delete
-                </Button>
+                {uId == post.userProfile.firebaseUserId ?
+                    <Button color="danger" onClick={() => navigate(`/posts/delete/${post.id}`)}>
+                        Delete
+                    </Button> : null
+                }
             </CardBody>
         </Card>
     )

--- a/Tabloid/client/src/components/Posts/PostDelete.js
+++ b/Tabloid/client/src/components/Posts/PostDelete.js
@@ -1,15 +1,19 @@
 import { useState, useEffect } from "react";
 import {useNavigate, useParams} from "react-router-dom";
 import {deletePost, getPostById} from "../../modules/postManager";
-import {Button, Form, FormGroup, Label} from "reactstrap";
+import {Button, Form, FormGroup, Label, Card} from "reactstrap";
+import firebase from "firebase/app";
+import "firebase/auth";
 
 export const PostDelete = () => {
     const [post, setPost] = useState({
-        title: ""
+        title: "",
+        userProfile: ""
     });
 
     const navigate = useNavigate();
     const {id} = useParams();
+    const uId = firebase.auth().currentUser.uid;
 
     const getPost = () => {
         getPostById(id)
@@ -25,20 +29,27 @@ export const PostDelete = () => {
         getPost()
     }, []);
 
-    return(
-        <Form>
-            <FormGroup>
-                <Label>Are you sure you'd like to delete the <b>{post.title} post?</b>
-                </Label>
-            </FormGroup>
-            <FormGroup>
-                <Button color="danger" onClick={() => handleClickDelete()}>
-                    Delete
-                </Button>
-                <Button onClick={() => navigate("/posts")}>
-                    Cancel
-                </Button>
-            </FormGroup>
-        </Form>
-    )
+    if (uId == post.userProfile.firebaseUserId)
+    {
+        return(
+            <Form>
+                <FormGroup>
+                    <Label>Are you sure you'd like to delete the <b>{post.title} post?</b>
+                    </Label>
+                </FormGroup>
+                <FormGroup>
+                    <Button color="danger" onClick={() => handleClickDelete()}>
+                        Delete
+                    </Button>
+                    <Button onClick={() => navigate("/posts")}>
+                        Cancel
+                    </Button>
+                </FormGroup>
+            </Form>
+        )
+    } else {
+        return (
+            <h1>GET OUT OF HERE YOU SNEAKY BASTARD!!!</h1>
+        )
+    }
 }

--- a/Tabloid/client/src/components/Posts/PostDelete.js
+++ b/Tabloid/client/src/components/Posts/PostDelete.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import {useNavigate, useParams} from "react-router-dom";
+import {deletePost, getPostById} from "../../modules/postManager";
+import {Button, Form, FormGroup, Label} from "reactstrap";
+
+export const PostDelete = () => {
+    const [post, setPost] = useState({
+        title: ""
+    });
+
+    const navigate = useNavigate();
+    const {id} = useParams();
+
+    const getPost = () => {
+        getPostById(id)
+        .then(post => setPost(post))
+    };
+
+    const handleClickDelete = () => {
+        deletePost(post.id)
+        .then(navigate("/posts"))
+    };
+
+    useEffect(() => {
+        getPost()
+    }, []);
+
+    return(
+        <Form>
+            <FormGroup>
+                <Label>Are you sure you'd like to delete the <b>{post.title} post?</b>
+                </Label>
+            </FormGroup>
+            <FormGroup>
+                <Button color="danger" onClick={() => handleClickDelete()}>
+                    Delete
+                </Button>
+                <Button onClick={() => navigate("/posts")}>
+                    Cancel
+                </Button>
+            </FormGroup>
+        </Form>
+    )
+}

--- a/Tabloid/client/src/components/Posts/UserPostList.js
+++ b/Tabloid/client/src/components/Posts/UserPostList.js
@@ -4,9 +4,11 @@ import { Post } from "./Post";
 import { Button } from "reactstrap";
 import { useNavigate } from "react-router-dom";
 
+
 export const UserPostList = () => {
 const [posts, setPosts] = useState([])
 const navigate = useNavigate();
+
 
 
 useEffect(() => {

--- a/Tabloid/client/src/modules/postManager.js
+++ b/Tabloid/client/src/modules/postManager.js
@@ -1,5 +1,3 @@
-import firebase from "firebase/app";
-import "firebase/auth";
 import { getToken } from "./authManager";
 
 const baseUrl = "/api/Post"
@@ -102,4 +100,5 @@ export const deletePost = (id) => {
         })
     })
 }
+
 

--- a/Tabloid/client/src/modules/postManager.js
+++ b/Tabloid/client/src/modules/postManager.js
@@ -82,3 +82,24 @@ export const addPost = (post) => {
     });
 };
 
+export const deletePost = (id) => {
+    return getToken().then((token) => {
+        return fetch(`${baseUrl}/${id}`, {
+            method: "DELETE",
+            headers: {
+                Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify(id)
+        }).then((res) => {
+            if (res.ok) {
+            } else if (res.status === 401) {
+                throw new Error("Unauthorized")
+            } else {
+                throw new Error(
+                    "An unknown error occured while trying to save a new tag."
+                )
+            }
+        })
+    })
+}
+


### PR DESCRIPTION
# Description
Add a description. Link the tickets that this PR closes.
Fixes # (issue)

Delete a post is up, can only delete currently logged in user posts, and all cascade deletes on PostTag, Comment, and PostReactions have been created


# Testing Instructions
Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

Open VS, create a new query and run this code 

ALTER TABLE PostTag
   DROP CONSTRAINT FK_PostTag_Post;

ALTER TABLE PostTag
    ADD CONSTRAINT FK_PostTag_Post
    FOREIGN KEY (PostId)
    REFERENCES Post (Id)
    ON DELETE CASCADE;

ALTER TABLE Comment
    DROP CONSTRAINT FK_Comment_Post;

ALTER TABLE Comment
    ADD CONSTRAINT FK_Comment_Post
    FOREIGN KEY (PostId)
    REFERENCES Post (Id)
    ON DELETE CASCADE;

ALTER TABLE PostReaction
    DROP CONSTRAINT FK_PostReaction_Post;

ALTER TABLE PostReaction
    ADD CONSTRAINT FK_PostReaction_Post
    FOREIGN KEY (PostId)
    REFERENCES Post (Id)
    ON DELETE CASCADE; 

Run tabloid from VS
NPM Start tabloid from terminal within the client folder
Log in to tabloid
Go to Posts or My Posts
You should only see the red delete button on posts of currently logged in users
Click delete button and you should be rerouted to a "are you sure" delete page
Click delete again and you should be rerouted to Posts index page and the targeted post should be deleted
If you attempt to go to posts/delete/ "enter a number that isn't the currently logged in users post" you get a surprise message.  Probably should have just rerouted you to index but where's the fun in that?

